### PR TITLE
🚑 Fix broken package references

### DIFF
--- a/Source/Anonymizer/DICOMAnonymizer.Tests/DICOMAnonymizer.Tests.csproj
+++ b/Source/Anonymizer/DICOMAnonymizer.Tests/DICOMAnonymizer.Tests.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Microsoft.Gateway/Microsoft.InnerEye.DicomConstraints.Tests/Microsoft.InnerEye.DicomConstraints.Tests.csproj
+++ b/Source/Microsoft.Gateway/Microsoft.InnerEye.DicomConstraints.Tests/Microsoft.InnerEye.DicomConstraints.Tests.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Microsoft.Gateway/Microsoft.InnerEye.Integration.Tests/Microsoft.InnerEye.Integration.Tests.csproj
+++ b/Source/Microsoft.Gateway/Microsoft.InnerEye.Integration.Tests/Microsoft.InnerEye.Integration.Tests.csproj
@@ -27,7 +27,7 @@
   </Target>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Microsoft.Gateway/Microsoft.InnerEye.Listener.Tests.Common/Microsoft.InnerEye.Listener.Tests.Common.csproj
+++ b/Source/Microsoft.Gateway/Microsoft.InnerEye.Listener.Tests.Common/Microsoft.InnerEye.Listener.Tests.Common.csproj
@@ -20,7 +20,7 @@
     <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Microsoft.Gateway/Microsoft.InnerEye.Listener.Tests/Microsoft.InnerEye.Listener.Tests.csproj
+++ b/Source/Microsoft.Gateway/Microsoft.InnerEye.Listener.Tests/Microsoft.InnerEye.Listener.Tests.csproj
@@ -27,7 +27,7 @@
   </Target>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     <PackageReference Include="HtmlRenderer.PdfSharp" Version="1.5.1-beta1" />
     <PackageReference Include="Markdig" Version="0.15.0" />

--- a/Source/Microsoft.Gateway/Microsoft.InnerEye.Listener.Tests/TestConfigurations/GatewayModelRulesConfig/GatewayModelRulesConfig.json
+++ b/Source/Microsoft.Gateway/Microsoft.InnerEye.Listener.Tests/TestConfigurations/GatewayModelRulesConfig/GatewayModelRulesConfig.json
@@ -7,7 +7,7 @@
         "AETConfigType": "Model",
         "ModelsConfig": [
           {
-            "ModelId": "PassThroughModel:4",
+            "ModelId": "PassThroughModel:1729",
             "ChannelConstraints": [
               {
                 "ChannelID": "ct",

--- a/Source/Microsoft.Gateway/Microsoft.InnerEye.Listener.Wix.Actions/Microsoft.InnerEye.Listener.Wix.Actions.csproj
+++ b/Source/Microsoft.Gateway/Microsoft.InnerEye.Listener.Wix.Actions/Microsoft.InnerEye.Listener.Wix.Actions.csproj
@@ -64,8 +64,8 @@
     <Reference Include="Microsoft.Extensions.Logging, Version=3.1.9.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Logging.3.1.9\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=3.1.9.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.3.1.9\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.6.0.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Extensions.Logging.Configuration, Version=3.1.9.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Extensions.Logging.Configuration.3.1.9\lib\netstandard2.0\Microsoft.Extensions.Logging.Configuration.dll</HintPath>

--- a/Source/Microsoft.Gateway/Microsoft.InnerEye.Listener.Wix.Actions/packages.config
+++ b/Source/Microsoft.Gateway/Microsoft.InnerEye.Listener.Wix.Actions/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.Extensions.DependencyInjection" version="6.0.0" targetFramework="net462" />
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="6.0.0" targetFramework="net462" />
   <package id="Microsoft.Extensions.Logging" version="6.0.0" targetFramework="net462" />
-  <package id="Microsoft.Extensions.Logging.Abstractions" version="6.0.1" targetFramework="net462" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="6.0.0" targetFramework="net462" />
   <package id="Microsoft.Extensions.Logging.Configuration" version="3.1.9" targetFramework="net462" />
   <package id="Microsoft.Extensions.Logging.Console" version="6.0.0" targetFramework="net462" />
   <package id="Microsoft.Extensions.Options" version="3.1.9" targetFramework="net462" />


### PR DESCRIPTION
Closes #96 

This PR fixes invalid package references in the Listener.Common that weren't upgraded correctly by dependabot.

It also includes minor changes to the testing config (upgrading the model version) to allow the newly-reactivated build pipeline to work correctly in the future, and hopefully prevent such issues.