### PR TITLE
Remove cron schedule on build job

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -5,8 +5,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  schedule:
-    - cron: '0 8 * * *'  # every day at 08:00
   repository_dispatch:
 
 env:


### PR DESCRIPTION
Remove this scheduled job as changes are made very infrequently, and whenever changes are made they are triggered anyway. Avoids more annoying notifications than necessary.